### PR TITLE
Fix choose default indentation

### DIFF
--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -228,9 +228,9 @@ action:
                 - service: switch.turn_on
                   target:
                     entity_id: "{{ repeat.item.switch }}"
-            default:
-              - service: switch.turn_off
-                target:
-                  entity_id: "{{ repeat.item.switch }}"
+          default:
+            - service: switch.turn_off
+              target:
+                entity_id: "{{ repeat.item.switch }}"
 
 mode: restart


### PR DESCRIPTION
## Summary
- fix indentation of default section under choose block in the blueprint so YAML parses

## Testing
- `ruby -ryaml -e 'YAML.load_file("blueprints/automation/multi_zone_climate.yaml")'`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861a3416ef08326993ddd676bd4058f