### PR TITLE
Add multi-sensor zone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ When creating an automation from the blueprint you will need to provide:
 - **Schedule Start/End Times** – the daily window during which the system operates.
 - **Climate Head-Unit** – the shared climate entity to control.
 - **Temperature & Humidity Thresholds** – values that trigger heating, cooling or dry mode.
-- **Zone Configuration** – for each zone specify its temperature sensor, humidity sensor and damper switch.
+- **Zone Configuration** – choose each zone's damper switch then add one or more
+  temperature and humidity sensors (up to eight zones).
 - **Enable/Override Flags** – input_boolean entities used to enable the schedule and to pause it manually.
 - **Damper Update Delay** – seconds to wait between damper adjustments.
 
@@ -22,13 +23,18 @@ When creating an automation from the blueprint you will need to provide:
 ```yaml
 zones:
   - name: Living Room
-    temp_sensor: sensor.living_room_temperature
-    humidity_sensor: sensor.living_room_humidity
     damper_switch: switch.living_room_damper
+    temp_sensors:
+      - sensor.living_room_temperature
+      - sensor.living_room_temperature_2
+    humidity_sensors:
+      - sensor.living_room_humidity
   - name: Bedroom
-    temp_sensor: sensor.bedroom_temperature
-    humidity_sensor: sensor.bedroom_humidity
     damper_switch: switch.bedroom_damper
+    temp_sensors:
+      - sensor.bedroom_temperature
+    humidity_sensors:
+      - sensor.bedroom_humidity
 ```
 
 Once configured, the automation will automatically set the head-unit's mode and temperature and toggle individual dampers based on zone urgency.

--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -105,10 +105,37 @@ blueprint:
     zones:
       name: Zones Configuration
       description: |
-        List each zone’s temp & humidity sensors plus its
-        damper switch.
+        Configure up to 8 zones. For each zone choose the damper
+        switch then add one or more temperature and humidity sensors.
+      default:
+        - name: Zone 1
+          damper_switch: ""
+          temp_sensors: []
+          humidity_sensors: []
       selector:
         object:
+          multiple: true
+          properties:
+            name:
+              type: string
+              description: Friendly name
+            damper_switch:
+              description: Switch controlling this zone’s damper
+              selector:
+                entity:
+                  domain: switch
+            temp_sensors:
+              description: Temperature sensors for this zone
+              selector:
+                entity:
+                  domain: sensor
+                  multiple: true
+            humidity_sensors:
+              description: Humidity sensors for this zone
+              selector:
+                entity:
+                  domain: sensor
+                  multiple: true
 
 trigger:
   - platform: time
@@ -144,10 +171,18 @@ action:
       zone_data: >
         {% set z=[] %}
         {% for zone in zones %}
-          {% set t_raw = states(zone.temp_sensor) %}
-          {% set t = t_raw | float if t_raw not in ['unknown','unavailable'] else none %}
-          {% set h_raw = states(zone.humidity_sensor) %}
-          {% set h = h_raw | float if h_raw not in ['unknown','unavailable'] else none %}
+          {% set temp_vals = zone.temp_sensors
+            | map('states')
+            | reject('in', ['unknown','unavailable'])
+            | map('float')
+            | list %}
+          {% set t = (temp_vals | sum / temp_vals | length) if temp_vals | length > 0 else none %}
+          {% set hum_vals = zone.humidity_sensors
+            | map('states')
+            | reject('in', ['unknown','unavailable'])
+            | map('float')
+            | list %}
+          {% set h = (hum_vals | sum / hum_vals | length) if hum_vals | length > 0 else none %}
           {% set heat_score = (low - t) if (t is not none and t < low) else 0 %}
           {% set cool_score = (t - high) if (t is not none and t > high) else 0 %}
           {% set dry_score  = (h - hum_h) if (h is not none and h > hum_h) else 0 %}


### PR DESCRIPTION
## Summary
- allow selecting damper switch then sensors when configuring zones
- support multiple temperature and humidity sensors per zone
- show a single zone by default and mention 8 zone limit
- average sensor values per zone

## Testing
- `python3 - <<'PY'
import yaml, sys
yaml.safe_load(open('blueprints/automation/multi_zone_climate.yaml'))
print('YAML OK')
PY` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6861aa54f01083269b759eea6b8d0758