### PR TITLE
Add minimal version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This repository provides a Home Assistant blueprint that coordinates a single HV
 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fbarneyonline%2Fha-multi-zone-climate%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fmulti_zone_climate.yaml)
 
+This blueprint uses object selectors with `multiple` and `properties`. These were
+introduced in **Home Assistant 2024.5**. Ensure your instance is running 2024.5
+or newer before importing.
+
 ## Configuration
 
 When creating an automation from the blueprint you will need to provide:

--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -6,6 +6,8 @@ blueprint:
     staggers per-zone damper control by urgency. Respects manual overrides and
     includes hysteresis.
   domain: automation
+  homeassistant: 2024.5.0
+  source_url: https://github.com/barneyonline/ha-multi-zone-climate/blob/main/blueprints/automation/multi_zone_climate.yaml
   input:
     # Scheduling
     start_time:


### PR DESCRIPTION
## Summary
- add Home Assistant minimum version and source URL to the blueprint
- document required Home Assistant version in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861acc7eef48326b8235d6fdc270f80