### PR TITLE
Update object selector format for HA 2025.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This repository provides a Home Assistant blueprint that coordinates a single HV
 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fbarneyonline%2Fha-multi-zone-climate%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fmulti_zone_climate.yaml)
 
-This blueprint uses object selectors with `multiple` and `properties`. These were
-introduced in **Home Assistant 2024.5**. Ensure your instance is running 2024.5
-or newer before importing.
+This blueprint uses object selectors with `multiple` and `fields`. These require
+**Home Assistant 2025.6** or newer. Ensure your instance is updated before
+importing.
 
 ## Configuration
 

--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -6,7 +6,8 @@ blueprint:
     staggers per-zone damper control by urgency. Respects manual overrides and
     includes hysteresis.
   domain: automation
-  homeassistant: 2024.5.0
+  homeassistant:
+    min_version: 2024.5.0
   source_url: https://github.com/barneyonline/ha-multi-zone-climate/blob/main/blueprints/automation/multi_zone_climate.yaml
   input:
     # Scheduling
@@ -181,53 +182,54 @@ blueprint:
       selector:
         object:
           multiple: true
-          properties:
-            name:
-              type: string
+          fields:
+            - name: name
               description: Friendly name
-            area:
+              selector:
+                text: {}
+            - name: area
               description: Home Assistant area for this zone
               selector:
                 area: {}
-            damper_switch:
+            - name: damper_switch
               description: Switch controlling this zone’s damper
               selector:
                 entity:
                   domain: switch
-            temp_sensors:
+            - name: temp_sensors
               description: Temperature sensors for this zone
               selector:
                 entity:
                   domain: sensor
                   multiple: true
-            humidity_sensors:
+            - name: humidity_sensors
               description: Humidity sensors for this zone
               selector:
                 entity:
                   domain: sensor
                   multiple: true
-            low_temp:
+            - name: low_temp
               description: Override low temperature threshold
               selector:
                 number:
                   min: 5
                   max: 30
                   unit_of_measurement: "°C"
-            high_temp:
+            - name: high_temp
               description: Override high temperature threshold
               selector:
                 number:
                   min: 15
                   max: 35
                   unit_of_measurement: "°C"
-            dry_temp:
+            - name: dry_temp
               description: Override dry-mode temperature threshold
               selector:
                 number:
                   min: 5
                   max: 30
                   unit_of_measurement: "°C"
-            hum_high:
+            - name: hum_high
               description: Override high humidity threshold
               selector:
                 number:


### PR DESCRIPTION
## Summary
- tweak README usage text for new object selectors
- switch blueprint `homeassistant` block to `min_version`
- update zones object selector to use `fields`

## Testing
- `python3 scripts/validate_blueprint.py blueprints/automation/multi_zone_climate.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6862999a3c248326b357769a777339e2