### PR TITLE
Fix blueprint import errors

### DIFF
--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -7,7 +7,7 @@ blueprint:
     includes hysteresis.
   domain: automation
   homeassistant:
-    min_version: 2025.6
+    min_version: "2025.6"
   source_url: https://github.com/barneyonline/ha-multi-zone-climate/blob/main/blueprints/automation/multi_zone_climate.yaml
   input:
     # Scheduling
@@ -183,59 +183,59 @@ blueprint:
         object:
           multiple: true
           fields:
-          name:
-            label: Friendly name
-            selector:
-              text: {}
-          area:
-            label: Home Assistant area for this zone
-            selector:
-              area: {}
-          damper_switch:
-            label: Switch controlling this zone’s damper
-            selector:
-              entity:
-                domain: switch
-          temp_sensors:
-            label: Temperature sensors for this zone
-            selector:
-              entity:
-                domain: sensor
-                multiple: true
-          humidity_sensors:
-            label: Humidity sensors for this zone
-            selector:
-              entity:
-                domain: sensor
-                multiple: true
-          low_temp:
-            label: Override low temperature threshold
-            selector:
-              number:
-                min: 5
-                max: 30
-                unit_of_measurement: "°C"
-          high_temp:
-            label: Override high temperature threshold
-            selector:
-              number:
-                min: 15
-                max: 35
-                unit_of_measurement: "°C"
-          dry_temp:
-            label: Override dry-mode temperature threshold
-            selector:
-              number:
-                min: 5
-                max: 30
-                unit_of_measurement: "°C"
-          hum_high:
-            label: Override high humidity threshold
-            selector:
-              number:
-                min: 20
-                max: 100
-                unit_of_measurement: "%"
+            name:
+              label: Friendly name
+              selector:
+                text: {}
+            area:
+              label: Home Assistant area for this zone
+              selector:
+                area: {}
+            damper_switch:
+              label: Switch controlling this zone’s damper
+              selector:
+                entity:
+                  domain: switch
+            temp_sensors:
+              label: Temperature sensors for this zone
+              selector:
+                entity:
+                  domain: sensor
+                  multiple: true
+            humidity_sensors:
+              label: Humidity sensors for this zone
+              selector:
+                entity:
+                  domain: sensor
+                  multiple: true
+            low_temp:
+              label: Override low temperature threshold
+              selector:
+                number:
+                  min: 5
+                  max: 30
+                  unit_of_measurement: "°C"
+            high_temp:
+              label: Override high temperature threshold
+              selector:
+                number:
+                  min: 15
+                  max: 35
+                  unit_of_measurement: "°C"
+            dry_temp:
+              label: Override dry-mode temperature threshold
+              selector:
+                number:
+                  min: 5
+                  max: 30
+                  unit_of_measurement: "°C"
+            hum_high:
+              label: Override high humidity threshold
+              selector:
+                number:
+                  min: 20
+                  max: 100
+                  unit_of_measurement: "%"
 trigger:
   - platform: time
     at: !input start_time


### PR DESCRIPTION
## Summary
- ensure `min_version` is quoted
- fix zones selector indentation

## Testing
- `python3 scripts/validate_blueprint.py blueprints/automation/multi_zone_climate.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6862e0a9ec0083269c462d78d34efeaa