### PR TITLE
Fix YAML syntax in blueprint validation workflow

### DIFF
--- a/.github/workflows/blueprint-validation.yaml
+++ b/.github/workflows/blueprint-validation.yaml
@@ -1,11 +1,16 @@
+---
 name: Validate Home Assistant blueprints
 
 on:
+  workflow_dispatch:
   pull_request:
-    paths: ['blueprints/**/*.ya?ml']
+    paths:
+      - 'blueprints/**/*.ya?ml'
   push:
-    branches: [main]
-    paths: ['blueprints/**/*.ya?ml']
+    branches:
+      - main
+    paths:
+      - 'blueprints/**/*.ya?ml'
 
 jobs:
   blueprint-check:
@@ -25,18 +30,21 @@ jobs:
           pip install --upgrade pip
           pip install "homeassistant==2025.6.0"
           python - <<'PY'
-from importlib.metadata import version
-import sys
-print("HA OK", version("homeassistant"), sys.version)
-PY
+          from importlib.metadata import version
+          import sys
+          print("HA OK", version("homeassistant"), sys.version)
+          PY
 
       - name: Determine files to validate
         id: files
         shell: bash
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            CHANGED=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" \
-                      | grep -E '^blueprints/.*\.ya?ml$' || true)
+            CHANGED=$(
+              git diff --name-only "${{ github.event.pull_request.base.sha }}" \
+                                  "${{ github.sha }}" |
+              grep -E '^blueprints/.*\.ya?ml$' || true
+            )
             echo "files=${CHANGED}" >> "$GITHUB_OUTPUT"
           else
             echo "files=blueprints/**/*.yaml" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- allow manual execution of blueprint validation workflow
- reformat event triggers into canonical YAML lists

## Testing
- `python -m yamllint .github/workflows/blueprint-validation.yaml && echo 'YAML OK'`


------
https://chatgpt.com/codex/tasks/task_e_6897f82159e083269166a885189a5b8a