### PR TITLE
Expose function toggles and zone enable flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ When creating an automation from the blueprint you will need to provide:
 - **Active Days** – days of the week when the schedule is enabled.
 - **Climate Head-Unit** – the shared climate entity to control.
 - **Temperature & Humidity Thresholds** – values that trigger heating, cooling or dry mode.
+- **Mode Toggles** – switches to enable or disable heating, cooling or dry mode as well as head-unit and damper control.
 - **Zone Configuration** – edit the YAML list of zones to specify each zone's damper switch and one or more temperature and/or humidity sensors. Optional overrides let you adjust thresholds per zone. Up to eight zones are supported.
+- **Zone Enable Flags** – optionally provide an `input_boolean` per zone to dynamically enable or disable that zone's damper.
 - **Enable/Override Flags** – input_boolean entities used to enable the schedule and to pause it manually.
 - **Damper Update Delay** – seconds to wait between zone damper changes.
 - **Update Interval** – how often the blueprint re-evaluates all zones (15s, 30s, 1m, 5m).
@@ -32,6 +34,7 @@ zones:
   - name: Living Room
     area: living_room
     damper_switch: switch.living_room_damper
+    enabled_flag: input_boolean.living_room_enabled
     temp_sensors:
       - sensor.living_room_temperature
     humidity_sensors:
@@ -42,6 +45,7 @@ zones:
   - name: Bedroom
     area: bedroom
     damper_switch: switch.bedroom_damper
+    enabled_flag: input_boolean.bedroom_enabled
     temp_sensors:
       - sensor.bedroom_temperature
     humidity_sensors:

--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -55,6 +55,36 @@ blueprint:
       name: Climate Head-Unit
       selector: { entity: { domain: climate } }
 
+    allow_heat:
+      name: Allow Heating Mode
+      description: Toggle to permit automatic heating mode selection.
+      default: true
+      selector: { boolean: {} }
+
+    allow_cool:
+      name: Allow Cooling Mode
+      description: Toggle to permit automatic cooling mode selection.
+      default: true
+      selector: { boolean: {} }
+
+    allow_dry:
+      name: Allow Dry Mode
+      description: Toggle to permit automatic dehumidifying mode selection.
+      default: true
+      selector: { boolean: {} }
+
+    control_head_unit:
+      name: Control Head-Unit
+      description: If disabled, the blueprint will not change the climate head-unit mode or temperature.
+      default: true
+      selector: { boolean: {} }
+
+    control_dampers:
+      name: Control Zone Dampers
+      description: If disabled, damper switches will not be toggled.
+      default: true
+      selector: { boolean: {} }
+
     low_temp:
       name: Low Temperature Threshold
       default: 19
@@ -124,10 +154,12 @@ blueprint:
           – damper_switch (required)
           – one or more temperature sensors and/or humidity sensors.
         Optional per-zone overrides let you tailor thresholds if they differ from globals.
+        You may also specify an input_boolean "enabled_flag" to dynamically enable or disable the zone.
       default:
         - name: Zone 1
           area: null
           damper_switch: ""
+          enabled_flag: ""
           temp_sensors: []
           humidity_sensors: []
           low_temp: null
@@ -196,6 +228,11 @@ actions:
       cool_buf:     !input cool_hysteresis
       dry_buf:      !input dry_hysteresis
       damper_delay: !input damper_delay
+      allow_heat:   !input allow_heat
+      allow_cool:   !input allow_cool
+      allow_dry:    !input allow_dry
+      control_head:    !input control_head_unit
+      control_dampers: !input control_dampers
 
       zone_data: >-
         {% set ns = namespace(out=[]) %}
@@ -203,48 +240,66 @@ actions:
           {# Normalize sensors: allow single entity_id or list #}
           {% set t_ents = z.temp_sensors if (z.temp_sensors is list or z.temp_sensors is tuple) else ([z.temp_sensors] if (z.temp_sensors is defined and z.temp_sensors is not none and z.temp_sensors != '') else []) %}
           {% set h_ents = z.humidity_sensors if (z.humidity_sensors is list or z.humidity_sensors is tuple) else ([z.humidity_sensors] if (z.humidity_sensors is defined and z.humidity_sensors is not none and z.humidity_sensors != '') else []) %}
-
           {% set has_sensors = (t_ents | length > 0) or (h_ents | length > 0) %}
-          {% if z.damper_switch and has_sensors %}
-            {% set t_vals = expand(t_ents)
-               | map(attribute='state')
-               | reject('in', ['unknown','unavailable','none','None','null'])
-               | map('float') | list %}
-            {% set h_vals = expand(h_ents)
-               | map(attribute='state')
-               | reject('in', ['unknown','unavailable','none','None','null'])
-               | map('float') | list %}
 
-            {% set temp = (t_vals | average(default=none)) %}
-            {% set hum  = (h_vals | average(default=none)) %}
+          {% set enabled = true %}
+          {% if z.enabled_flag is defined and z.enabled_flag not in ['', none] %}
+            {% set enabled = is_state(z.enabled_flag, 'on') %}
+          {% endif %}
 
-            {% set z_low    = (z.low_temp  | default(low,  true)) | float %}
-            {% set z_high   = (z.high_temp | default(high, true)) | float %}
-            {% set z_dry_t  = (z.dry_temp  | default(dry_t, true))| float %}
-            {% set z_hum_h  = (z.hum_high  | default(hum_h, true))| float %}
+          {% if z.damper_switch %}
+            {% set data = {
+              'switch': z.damper_switch,
+              'temp': none,
+              'hum': none,
+              'heat': 0,
+              'cool': 0,
+              'dry': 0,
+              'urgency': 0
+            } %}
 
-            {% set hbuf = heat_buf | float(0) %}
-            {% set cbuf = cool_buf | float(0) %}
-            {% set dbuf = dry_buf  | float(0) %}
+            {% if enabled and has_sensors %}
+              {% set t_vals = expand(t_ents)
+                 | map(attribute='state')
+                 | reject('in', ['unknown','unavailable','none','None','null'])
+                 | map('float') | list %}
+              {% set h_vals = expand(h_ents)
+                 | map(attribute='state')
+                 | reject('in', ['unknown','unavailable','none','None','null'])
+                 | map('float') | list %}
 
-            {% set heat_sc = (z_low - temp)
-               if (temp is not none and temp < z_low - hbuf) else 0 %}
-            {% set cool_sc = (temp - z_high)
-               if (temp is not none and temp > z_high + cbuf) else 0 %}
-            {% set dry_sc  = (hum - z_hum_h)
-               if (hum  is not none and hum  > z_hum_h + dbuf
-                   and temp is not none and temp > z_dry_t) else 0 %}
-            {% set urg = [heat_sc, cool_sc, dry_sc] | max %}
+              {% set temp = (t_vals | average(default=none)) %}
+              {% set hum  = (h_vals | average(default=none)) %}
 
-            {% set ns.out = ns.out + [{
-              'switch':   z.damper_switch,
-              'temp':     temp,
-              'hum':      hum,
-              'heat':     heat_sc,
-              'cool':     cool_sc,
-              'dry':      dry_sc,
-              'urgency':  urg
-            }] %}
+              {% set z_low    = (z.low_temp  | default(low,  true)) | float %}
+              {% set z_high   = (z.high_temp | default(high, true)) | float %}
+              {% set z_dry_t  = (z.dry_temp  | default(dry_t, true))| float %}
+              {% set z_hum_h  = (z.hum_high  | default(hum_h, true))| float %}
+
+              {% set hbuf = heat_buf | float(0) %}
+              {% set cbuf = cool_buf | float(0) %}
+              {% set dbuf = dry_buf  | float(0) %}
+
+              {% set heat_sc = (z_low - temp)
+                 if (allow_heat and temp is not none and temp < z_low - hbuf) else 0 %}
+              {% set cool_sc = (temp - z_high)
+                 if (allow_cool and temp is not none and temp > z_high + cbuf) else 0 %}
+              {% set dry_sc  = (hum - z_hum_h)
+                 if (allow_dry and hum  is not none and hum  > z_hum_h + dbuf and temp is not none and temp > z_dry_t) else 0 %}
+              {% set urg = [heat_sc, cool_sc, dry_sc] | max %}
+
+              {% set data = {
+                'switch':   z.damper_switch,
+                'temp':     temp,
+                'hum':      hum,
+                'heat':     heat_sc,
+                'cool':     cool_sc,
+                'dry':      dry_sc,
+                'urgency':  urg
+              } %}
+            {% endif %}
+
+            {% set ns.out = ns.out + [data] %}
           {% endif %}
         {% endfor %}
         {{ ns.out | sort(attribute='urgency', reverse=true) }}
@@ -268,35 +323,40 @@ actions:
         {% elif mode == 'cool' %}{{ cool_sp | float(high) }}
         {% else %}none{% endif %}
 
-  - action: climate.set_hvac_mode
-    target:
-      entity_id: !input head_unit
-    data:
-      hvac_mode: "{{ mode }}"
-
   - choose:
-      - conditions: "{{ mode in ['heat', 'cool'] }}"
+      - conditions: "{{ control_head }}"
         sequence:
-          - action: climate.set_temperature
+          - action: climate.set_hvac_mode
             target:
               entity_id: !input head_unit
             data:
-              temperature: "{{ set_temp }}"
+              hvac_mode: "{{ mode }}"
+          - choose:
+              - conditions: "{{ mode in ['heat', 'cool'] }}"
+                sequence:
+                  - action: climate.set_temperature
+                    target:
+                      entity_id: !input head_unit
+                    data:
+                      temperature: "{{ set_temp }}"
 
-  - repeat:
-      for_each: "{{ zone_data }}"
-      sequence:
-        - delay:
-            seconds: "{{ damper_delay | int }}"
-        - choose:
-            - conditions: "{{ repeat.item.urgency > 0 }}"
+  - choose:
+      - conditions: "{{ control_dampers }}"
+        sequence:
+          - repeat:
+              for_each: "{{ zone_data }}"
               sequence:
-                - action: switch.turn_on
-                  target:
-                    entity_id: "{{ repeat.item.switch }}"
-          default:
-            - action: switch.turn_off
-              target:
-                entity_id: "{{ repeat.item.switch }}"
+                - delay:
+                    seconds: "{{ damper_delay | int }}"
+                - choose:
+                    - conditions: "{{ repeat.item.urgency > 0 }}"
+                      sequence:
+                        - action: switch.turn_on
+                          target:
+                            entity_id: "{{ repeat.item.switch }}"
+                  default:
+                    - action: switch.turn_off
+                      target:
+                        entity_id: "{{ repeat.item.switch }}"
 
 mode: restart


### PR DESCRIPTION
## Summary
- add boolean inputs to enable or disable heating, cooling, dry modes, head-unit control and damper control
- allow each zone to reference an input_boolean `enabled_flag` to toggle its damper participation
- document new toggles and flags in README

## Testing
- `python scripts/ha_blueprint_validate.py blueprints/automation/multi_zone_climate.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68bb7f90b9588326bcabeca960a6b8db