### PR TITLE
Only retune dampers on HVAC mode change

### DIFF
--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -527,7 +527,7 @@ actions:
                                   entity_id: "{{ sync_script }}"
 
       - choose:
-          - conditions: "{{ control_dampers }}"
+          - conditions: "{{ control_dampers and mode != 'off' }}"
             sequence:
               - repeat:
                   for_each: "{{ zone_data }}"


### PR DESCRIPTION
## Summary
- only dispatch damper toggles when the head unit hvac mode actually changes
- keep existing damper states when the head unit enters hvac_mode off

## Testing
- python3 scripts/ha_blueprint_validate.py blueprints/automation/multi_zone_climate.yaml
