### PR TITLE
Restore time-based automation triggers

### DIFF
--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -253,20 +253,12 @@ variables:
 
 trigger_variables:
   _interval: !input update_interval
-  _persons: !input persons
 
 triggers:
   - trigger: time
     at: !input start_time
   - trigger: time
     at: !input end_time
-  - trigger: state
-    entity_id: !input enabled_flag
-  - trigger: state
-    entity_id: !input manual_override
-  - trigger: state
-    entity_id: !input persons
-    enabled: "{{ _persons | length > 0 }}"
   # Recalculate regularly so zone dampers/head unit respond to sensor changes
   - trigger: time_pattern
     minutes: "/1"


### PR DESCRIPTION
## Summary

Restore the dynamic climate blueprint to time-based triggers only by removing the recently added state triggers for the enable flag, manual override flag, and presence entities. This narrows automation execution back to schedule boundaries and the configured periodic interval so the automation no longer re-enters immediately on state flips and cascades into repeated zone temperature updates.

## Related Issues

Addresses user-reported automation run storms and zone temperature service errors after the trigger expansion.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

List the exact commands you ran. Prefer the pinned Docker environment from `devtools/docker/`.

```bash
python3 scripts/ha_blueprint_validate.py blueprints/automation/multi_zone_climate.yaml
python3 - <<'PY'
from pathlib import Path
import yaml

class Loader(yaml.SafeLoader):
    pass

def passthrough(loader, tag_suffix, node):
    if isinstance(node, yaml.ScalarNode):
        return loader.construct_scalar(node)
    if isinstance(node, yaml.SequenceNode):
        return loader.construct_sequence(node)
    return loader.construct_mapping(node)

Loader.add_multi_constructor('!', passthrough)
path = Path('blueprints/automation/multi_zone_climate.yaml')
with path.open('r', encoding='utf-8') as f:
    yaml.load(f, Loader=Loader)
print('YAML_OK')
PY
```

Add any extra commands, targeted tests, or manual validation below.

- `python3 scripts/ha_blueprint_validate.py ...` is currently blocked locally because the `homeassistant` package is not installed in this workspace.
- The custom YAML load completed successfully and confirmed the edited blueprint still parses.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The regression source was commit `98804b2`, which introduced state-based triggers for `enabled_flag`, `manual_override`, and `persons` on top of the existing time-based schedule and interval triggers.