### PR TITLE
Handle damper timeout errors gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,14 @@ zones:
 ```
 
 Once configured, the automation will automatically set the head-unit's mode and temperature and toggle individual dampers based on zone urgency. Heating and cooling thresholds are evaluated as start points, while hysteresis is only used to decide when an already-active zone can stop calling for that mode. When there is no active demand, the blueprint also closes any dampers it previously opened so zone state does not drift stale.
+
+## Troubleshooting
+
+If you see a Home Assistant error like `Connection timeout to host http://<airbase-ip>/skyfi/aircon/set_zone_setting`, the failure is coming from the HVAC controller or the path to it rather than from blueprint templating. On Daikin AirBase systems, each zone switch call is translated by the integration into a request against the controller's `set_zone_setting` endpoint.
+
+The blueprint already avoids no-op damper writes, and individual damper service failures are allowed to continue so one slow zone update does not abort the whole automation run. If the timeout persists, check:
+
+- The controller at the logged IP is reachable and responsive on your LAN.
+- The selected damper entities are the intended zone switches for that controller.
+- Your `Update Interval` is not shorter than the time needed to work through a full damper sequence, especially when `Damper Update Delay` is high.
+- The controller is not busy or temporarily unavailable when many zone changes are requested in a short period.

--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -619,6 +619,7 @@ actions:
                                     - delay:
                                         seconds: "{{ damper_delay | int(0) }}"
                                 - action: switch.turn_off
+                                  continue_on_error: true
                                   target:
                                     entity_id: "{{ repeat.item.switch }}"
 
@@ -708,6 +709,7 @@ actions:
                                   entity_id: !input manual_override
                                   state: "off"
                                 - action: switch.turn_on
+                                  continue_on_error: true
                                   target:
                                     entity_id: "{{ repeat.item.switch }}"
                             - conditions: "{{ (not wants_open) and current_open }}"
@@ -722,6 +724,7 @@ actions:
                                   entity_id: !input manual_override
                                   state: "off"
                                 - action: switch.turn_off
+                                  continue_on_error: true
                                   target:
                                     entity_id: "{{ repeat.item.switch }}"
 


### PR DESCRIPTION
## Summary

Prevent individual zone damper service-call failures from aborting the entire automation run.

This change adds `continue_on_error: true` to the damper `switch.turn_on` and `switch.turn_off` actions in the blueprint, so intermittent Daikin AirBase connection timeouts do not stop the rest of the schedule logic. It also documents the timeout failure mode and likely causes in the README.

## Related Issues

Triggered by a reported Home Assistant automation failure when `pydaikin` timed out connecting to `/skyfi/aircon/set_zone_setting` on the AirBase controller.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

List the exact commands you ran.

```bash
python3 - <<'PY'
import yaml
from pathlib import Path

class Loader(yaml.SafeLoader):
    pass

def unknown(loader, tag_suffix, node):
    if isinstance(node, yaml.ScalarNode):
        return loader.construct_scalar(node)
    if isinstance(node, yaml.SequenceNode):
        return loader.construct_sequence(node)
    if isinstance(node, yaml.MappingNode):
        return loader.construct_mapping(node)
    return None

Loader.add_multi_constructor('', unknown)
for rel in ['blueprints/automation/multi_zone_climate.yaml']:
    path = Path(rel)
    with path.open() as f:
        yaml.load(f, Loader=Loader)
print('YAML parse ok')
PY
python3 scripts/ha_blueprint_validate.py blueprints/automation/multi_zone_climate.yaml
```

Extra validation notes:
- The YAML parse completed successfully.
- `python3 scripts/ha_blueprint_validate.py blueprints/automation/multi_zone_climate.yaml` could not run in this local environment because the `homeassistant` Python package is not installed.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The underlying error is an `aiohttp.client_exceptions.ConnectionTimeoutError` raised by `pydaikin` while toggling a zone switch. This PR does not change the controller/integration timeout behaviour itself; it keeps the automation from failing outright when a single zone update times out.