### PR TITLE
Skip zone temp updates until mode is ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ When creating an automation from the blueprint you will need to provide:
 - **Schedule Start/End Times** – the daily window during which the system operates.
 - **Active Days** – days of the week when the schedule is enabled.
 - **Climate Head-Unit** – the shared climate entity to control.
-- **Zone Temperature Climate Entities** – optional additional climate entities (for example per-zone temperature entities) that should track a zone-specific setpoint derived from the head-unit target. In `heat` mode the blueprint sends `head-unit target + offset`; in `cool` mode it sends `head-unit target - offset`. If one of them cannot accept the computed setpoint, it will be skipped rather than failing the whole automation.
+- **Zone Temperature Climate Entities** – optional additional climate entities (for example per-zone temperature entities) that should track a zone-specific setpoint derived from the head-unit target. In `heat` mode the blueprint sends `head-unit target + offset`; in `cool` mode it sends `head-unit target - offset`. If one of them is not ready for the selected heat/cool mode or cannot accept the computed setpoint, it will be skipped rather than failing the whole automation.
 - **Zone Temperature Offset** – the adjustable `+/-` value used when updating the optional zone climate entities. The default is `1°C`, so a heat target of `20°C` becomes `21°C` for zones and a cool target of `23°C` becomes `22°C`.
 - **Temperature & Humidity Thresholds** – zone start thresholds for heating, cooling or dry mode. A common setup is `heat setpoint - 1°C` and `cool setpoint + 1°C`.
 - **Mode Toggles** – switches to enable or disable heating, cooling or dry mode as well as head-unit and damper control.

--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -214,7 +214,7 @@ blueprint:
 
     zone_temperature_entities:
       name: Zone Temperature Climate Entities (optional)
-      description: Additional climate entities to keep aligned with a mode-adjusted zone target temperature. In heat mode the zone target is the head-unit setpoint plus the zone temperature offset. In cool mode it is the head-unit setpoint minus the offset. Entities that cannot accept the computed setpoint are skipped.
+      description: Additional climate entities to keep aligned with a mode-adjusted zone target temperature. In heat mode the zone target is the head-unit setpoint plus the zone temperature offset. In cool mode it is the head-unit setpoint minus the offset. Entities that are not ready for the selected heat/cool mode or cannot accept the computed setpoint are skipped.
       default: []
       selector:
         entity:
@@ -671,10 +671,25 @@ actions:
                                   - condition: state
                                     entity_id: !input manual_override
                                     state: "off"
+                                  - variables:
+                                      ready_extra_temp_targets_to_update: >-
+                                        {% if states(head_entity) != mode %}
+                                          []
+                                        {% else %}
+                                          {% set ns = namespace(ids=[]) %}
+                                          {% for entity in extra_temp_targets_to_update %}
+                                            {% if states(entity) == mode %}
+                                              {% set ns.ids = ns.ids + [entity] %}
+                                            {% endif %}
+                                          {% endfor %}
+                                          {{ ns.ids }}
+                                        {% endif %}
+                                  - condition: template
+                                    value_template: "{{ ready_extra_temp_targets_to_update | length > 0 }}"
                                   - action: climate.set_temperature
                                     continue_on_error: true
                                     target:
-                                      entity_id: "{{ extra_temp_targets_to_update }}"
+                                      entity_id: "{{ ready_extra_temp_targets_to_update }}"
                                     data:
                                       temperature: "{{ zone_set_temp }}"
 


### PR DESCRIPTION
## Summary

Skip optional zone temperature climate entity updates unless the head unit and each target zone climate entity are currently in the selected `heat` or `cool` mode. This avoids Home Assistant service errors from integrations that reject zone setpoint changes while the main climate mode is not ready.

Also updates the blueprint input help text and README to describe the skip behavior.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
ruby -e 'require "yaml"; YAML.load_file("blueprints/automation/multi_zone_climate.yaml"); puts "YAML parse OK"'
git diff --check
```

Additional attempted validation:

```bash
python3 scripts/ha_blueprint_validate.py blueprints/automation/multi_zone_climate.yaml
```

This could not run locally because the `homeassistant` Python package is not installed in this environment.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The failed automation path was caused by `climate.set_temperature` reaching zone climate entities before their exposed state was ready for the selected heat/cool mode. The blueprint now filters those targets immediately before the service call.