### PR TITLE
Guard damper updates when controller is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ When creating an automation from the blueprint you will need to provide:
 - **Zone Temperature Offset** – the adjustable `+/-` value used when updating the optional zone climate entities. The default is `1°C`, so a heat target of `20°C` becomes `21°C` for zones and a cool target of `23°C` becomes `22°C`.
 - **Temperature & Humidity Thresholds** – zone start thresholds for heating, cooling or dry mode. A common setup is `heat setpoint - 1°C` and `cool setpoint + 1°C`.
 - **Mode Toggles** – switches to enable or disable heating, cooling or dry mode as well as head-unit and damper control.
+- **Damper Controller Availability Entity** – optional reachability entity for the zone controller. For Daikin AirBase, use a ping/connectivity sensor for the AirBase IP so damper writes are skipped while the controller is offline or not responding.
 - **Zone Configuration** – edit the YAML list of zones to specify each zone's damper switch and one or more temperature and/or humidity sensors. Optional overrides let you adjust thresholds per zone. Up to eight zones are supported.
 - **Zone Enable Flags** – optionally provide an `input_boolean` per zone to dynamically enable or disable that zone's damper.
 - **Enable/Override Flags** – input_boolean entities used to enable the schedule and to pause active automatic control manually. When the schedule window ends, nobody is home, or the automation is disabled, the blueprint turns the head unit off and closes dampers.
@@ -59,10 +60,11 @@ Once configured, the automation will automatically set the head-unit's mode and 
 
 ## Troubleshooting
 
-If you see a Home Assistant error like `Connection timeout to host http://<airbase-ip>/skyfi/aircon/set_zone_setting`, the failure is coming from the HVAC controller or the path to it rather than from blueprint templating. On Daikin AirBase systems, each zone switch call is translated by the integration into a request against the controller's `set_zone_setting` endpoint.
+If you see a Home Assistant error like `Connection timeout to host http://<airbase-ip>/skyfi/aircon/get_zone_setting`, the failure is coming from the HVAC controller or the path to it rather than from blueprint templating. On Daikin AirBase systems, each zone switch call is translated by the integration into requests against the controller's `get_zone_setting` and `set_zone_setting` endpoints.
 
-The blueprint already avoids no-op damper writes, and individual damper service failures are allowed to continue so one slow zone update does not abort the whole automation run. If the timeout persists, check:
+The blueprint avoids no-op damper writes, skips overlapping scheduled runs instead of queueing them behind a slow controller, and can skip damper writes entirely while an optional controller availability entity is not ready. If the timeout persists:
 
+- Add a ping/connectivity sensor for the controller IP and select it as **Damper Controller Availability Entity**.
 - The controller at the logged IP is reachable and responsive on your LAN.
 - The selected damper entities are the intended zone switches for that controller.
 - Your `Update Interval` is not shorter than the time needed to work through a full damper sequence, especially when `Damper Update Delay` is high.

--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -93,6 +93,13 @@ blueprint:
       default: true
       selector: { boolean: {} }
 
+    damper_controller_available:
+      name: Damper Controller Availability Entity (optional)
+      description: Optional binary_sensor, sensor, or switch that reports whether the damper controller is reachable. If provided, damper service calls are skipped unless this entity is on, home, open, or connected.
+      default: ""
+      selector:
+        entity: {}
+
     low_temp:
       name: Low Temperature Threshold
       description: Heating starts below this zone temperature. A typical value is 1°C below the head-unit heat setpoint.
@@ -364,6 +371,7 @@ actions:
       allow_dry: !input allow_dry
       control_head: !input control_head_unit
       control_dampers: !input control_dampers
+      damper_controller_available_entity: !input damper_controller_available
       zone_temp_entities: !input zone_temperature_entities
       zone_temp_offset: !input zone_temperature_offset
       current_hvac_mode: >-
@@ -398,6 +406,20 @@ actions:
 
       automation_active: >-
         {{ is_state(enabled_flag_entity, 'on') and presence_active and schedule_active }}
+
+      damper_controller_available_state: >-
+        {% if damper_controller_available_entity in [none, '', []] %}
+          available
+        {% else %}
+          {{ states(damper_controller_available_entity) }}
+        {% endif %}
+
+      dampers_available: >-
+        {% if damper_controller_available_entity in [none, '', []] %}
+          true
+        {% else %}
+          {{ damper_controller_available_state in ['on', 'home', 'open', 'connected'] }}
+        {% endif %}
 
       zone_data: >-
         {% set ns = namespace(out=[]) %}
@@ -602,13 +624,14 @@ actions:
                       hvac_mode: "off"
 
           - choose:
-              - conditions: "{{ control_dampers }}"
+              - conditions: "{{ control_dampers and dampers_available }}"
                 sequence:
                   - repeat:
                       for_each: "{{ zone_data }}"
                       sequence:
                         - variables:
-                            current_open: "{{ is_state(repeat.item.switch, 'on') }}"
+                            switch_state: "{{ states(repeat.item.switch) }}"
+                            current_open: "{{ switch_state == 'on' }}"
                         - choose:
                             - conditions: "{{ current_open }}"
                               sequence:
@@ -694,7 +717,7 @@ actions:
                                       temperature: "{{ zone_set_temp }}"
 
           - choose:
-              - conditions: "{{ control_dampers }}"
+              - conditions: "{{ control_dampers and dampers_available }}"
                 sequence:
                   - condition: state
                     entity_id: !input manual_override
@@ -710,9 +733,11 @@ actions:
                               {{ (mode == 'heat' and repeat.item.heat > 0)
                                  or (mode == 'cool' and repeat.item.cool > 0)
                                  or (mode == 'dry' and repeat.item.dry > 0) }}
-                            current_open: "{{ is_state(repeat.item.switch, 'on') }}"
+                            switch_state: "{{ states(repeat.item.switch) }}"
+                            switch_ready: "{{ switch_state not in ['unknown', 'unavailable'] }}"
+                            current_open: "{{ switch_state == 'on' }}"
                         - choose:
-                            - conditions: "{{ wants_open and not current_open }}"
+                            - conditions: "{{ switch_ready and wants_open and not current_open }}"
                               sequence:
                                 - if:
                                     - condition: template
@@ -727,7 +752,7 @@ actions:
                                   continue_on_error: true
                                   target:
                                     entity_id: "{{ repeat.item.switch }}"
-                            - conditions: "{{ (not wants_open) and current_open }}"
+                            - conditions: "{{ switch_ready and (not wants_open) and current_open }}"
                               sequence:
                                 - if:
                                     - condition: template
@@ -743,4 +768,5 @@ actions:
                                   target:
                                     entity_id: "{{ repeat.item.switch }}"
 
-mode: queued
+mode: single
+max_exceeded: silent


### PR DESCRIPTION
## Summary

Add an optional damper controller availability entity so Daikin AirBase zone switch calls are skipped while the controller is offline or not responding. Also avoid damper writes for unavailable switch entities and change the schedule automation to `single` mode so slow controller calls do not accumulate queued runs.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
python3 - <<'PY'
import yaml
from pathlib import Path
class Loader(yaml.SafeLoader):
    pass
Loader.add_constructor('!input', lambda loader, node: {'!input': loader.construct_scalar(node)})
path = Path('blueprints/automation/multi_zone_climate.yaml')
with path.open() as f:
    data = yaml.load(f, Loader=Loader)
print(f'{path}: parsed, top-level keys={list(data)}')
PY
python3 -m py_compile scripts/ha_blueprint_validate.py
```

Could not run `python3 scripts/ha_blueprint_validate.py blueprints/automation/multi_zone_climate.yaml` locally because the workspace does not have the `homeassistant` package installed.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Root cause: the Daikin integration raises a connection timeout while resolving AirBase zone settings, and that unexpected service exception can abort the automation run. The new availability gate lets users select a ping/connectivity entity for the AirBase IP so damper writes are skipped while the controller is unreachable.