### PR TITLE
Guard Daikin zone temperature updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ When creating an automation from the blueprint you will need to provide:
 - **Schedule Start/End Times** – the daily window during which the system operates.
 - **Active Days** – days of the week when the schedule is enabled.
 - **Climate Head-Unit** – the shared climate entity to control.
-- **Zone Temperature Climate Entities** – optional additional climate entities (for example per-zone temperature entities) that should track a zone-specific setpoint derived from the head-unit target. In `heat` mode the blueprint sends `head-unit target + offset`; in `cool` mode it sends `head-unit target - offset`. If one of them is not ready for the selected heat/cool mode or cannot accept the computed setpoint, it will be skipped rather than failing the whole automation.
+- **Zone Temperature Climate Entities** – optional additional climate entities (for example per-zone temperature entities) that should track a zone-specific setpoint derived from the head-unit target. In `heat` mode the blueprint sends `head-unit target + offset`; in `cool` mode it sends `head-unit target - offset`. Entities that are not ready for the selected heat/cool mode, do not advertise target-temperature support, or cannot accept the computed setpoint range are skipped.
 - **Zone Temperature Offset** – the adjustable `+/-` value used when updating the optional zone climate entities. The default is `1°C`, so a heat target of `20°C` becomes `21°C` for zones and a cool target of `23°C` becomes `22°C`.
 - **Temperature & Humidity Thresholds** – zone start thresholds for heating, cooling or dry mode. A common setup is `heat setpoint - 1°C` and `cool setpoint + 1°C`.
 - **Mode Toggles** – switches to enable or disable heating, cooling or dry mode as well as head-unit and damper control.
@@ -69,3 +69,5 @@ The blueprint avoids no-op damper writes, skips overlapping scheduled runs inste
 - The selected damper entities are the intended zone switches for that controller.
 - Your `Update Interval` is not shorter than the time needed to work through a full damper sequence, especially when `Damper Update Delay` is high.
 - The controller is not busy or temporarily unavailable when many zone changes are requested in a short period.
+
+If you see `Failed to set zone temperature. The device may not support this operation`, the failing call is the optional **Zone Temperature Climate Entities** sync. On Daikin zone climate entities this message is generic: it can mean the controller rejected that particular zone-temperature write even when the device normally supports zone temperature changes. Check whether the target is within the zone's current min/max range and whether the error appears during mode or head-unit setpoint changes.

--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -221,7 +221,7 @@ blueprint:
 
     zone_temperature_entities:
       name: Zone Temperature Climate Entities (optional)
-      description: Additional climate entities to keep aligned with a mode-adjusted zone target temperature. In heat mode the zone target is the head-unit setpoint plus the zone temperature offset. In cool mode it is the head-unit setpoint minus the offset. Entities that are not ready for the selected heat/cool mode or cannot accept the computed setpoint are skipped.
+      description: Additional climate entities to keep aligned with a mode-adjusted zone target temperature. In heat mode the zone target is the head-unit setpoint plus the zone temperature offset. In cool mode it is the head-unit setpoint minus the offset. Entities that are not ready for the selected heat/cool mode, do not advertise target-temperature support, or cannot accept the computed setpoint range are skipped.
       default: []
       selector:
         entity:
@@ -568,6 +568,8 @@ actions:
           {% set ns = namespace(ids=[]) %}
           {% for entity in extra_temp_targets %}
             {% set current = state_attr(entity, 'temperature') %}
+            {% set supported_features = state_attr(entity, 'supported_features') | int(0) %}
+            {% set supports_target_temperature = (supported_features % 2) == 1 %}
             {% set min_value = state_attr(entity, 'min_temp') | float(default=none) %}
             {% set max_value = state_attr(entity, 'max_temp') | float(default=none) %}
             {% set step = state_attr(entity, 'target_temp_step') | float(0) %}
@@ -576,7 +578,8 @@ actions:
               {% set rounded = (((target / step) | round(0)) * step) | round(4) %}
               {% set step_ok = ((rounded - target) | abs) < 0.001 %}
             {% endif %}
-            {% if (min_value is none or target >= min_value)
+            {% if supports_target_temperature
+               and (min_value is none or target >= min_value)
                and (max_value is none or target <= max_value)
                and step_ok
                and (current in [none, '', 'unknown', 'unavailable']
@@ -709,12 +712,29 @@ actions:
                                         {% endif %}
                                   - condition: template
                                     value_template: "{{ ready_extra_temp_targets_to_update | length > 0 }}"
-                                  - action: climate.set_temperature
-                                    continue_on_error: true
-                                    target:
-                                      entity_id: "{{ ready_extra_temp_targets_to_update }}"
-                                    data:
-                                      temperature: "{{ zone_set_temp }}"
+                                  - delay:
+                                      seconds: 2
+                                  - condition: state
+                                    entity_id: !input manual_override
+                                    state: "off"
+                                  - repeat:
+                                      for_each: "{{ ready_extra_temp_targets_to_update }}"
+                                      sequence:
+                                        - if:
+                                            - condition: template
+                                              value_template: "{{ not repeat.first }}"
+                                          then:
+                                            - delay:
+                                                seconds: 1
+                                        - condition: state
+                                          entity_id: !input manual_override
+                                          state: "off"
+                                        - action: climate.set_temperature
+                                          continue_on_error: true
+                                          target:
+                                            entity_id: "{{ repeat.item }}"
+                                          data:
+                                            temperature: "{{ zone_set_temp }}"
 
           - choose:
               - conditions: "{{ control_dampers and dampers_available }}"


### PR DESCRIPTION
## Summary

Adds defensive handling for optional zone temperature climate syncs so Daikin zone temperature updates are filtered, settled, and sent sequentially instead of as one bulk service call. This reduces transient failures during mode/head-unit setpoint transitions and keeps one rejected zone write from blocking the rest.

Also clarifies the README troubleshooting note for Daikin's generic `Failed to set zone temperature` message.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
python3 - <<'PY'
from pathlib import Path
import yaml

class Loader(yaml.SafeLoader):
    pass

def unknown_constructor(loader, tag_suffix, node):
    if isinstance(node, yaml.ScalarNode):
        return loader.construct_scalar(node)
    if isinstance(node, yaml.SequenceNode):
        return loader.construct_sequence(node)
    if isinstance(node, yaml.MappingNode):
        return loader.construct_mapping(node)
    return None

Loader.add_multi_constructor('!', unknown_constructor)
path = Path('blueprints/automation/multi_zone_climate.yaml')
with path.open() as fh:
    data = yaml.load(fh, Loader=Loader)
print('YAML parsed:', isinstance(data, dict), 'top-level keys:', ', '.join(data.keys()))
PY
python3 scripts/ha_blueprint_validate.py blueprints/automation/multi_zone_climate.yaml
```

YAML parse passed. `ha_blueprint_validate.py` could not run in this local environment because the `homeassistant` Python package is not installed: `ModuleNotFoundError: No module named 'homeassistant'`.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The Daikin integration raises the same generic zone-temperature error when a supported controller rejects a specific write, so the blueprint now avoids obvious invalid targets and spaces out zone climate writes around head-unit transitions.