### PR TITLE
Wait for zone climate mode before temperature sync

### DIFF
--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -675,7 +675,7 @@ actions:
                     entity_id: !input manual_override
                     state: "off"
                   - choose:
-                      - conditions: "{{ mode in ['heat', 'cool'] and set_temp not in [none, '', []] and states(head_entity) in ['heat', 'cool'] }}"
+                      - conditions: "{{ mode in ['heat', 'cool'] and set_temp not in [none, '', []] and states(head_entity) == mode }}"
                         sequence:
                           - choose:
                               - conditions: "{{ head_needs_temp_update }}"
@@ -697,6 +697,20 @@ actions:
                                   - condition: state
                                     entity_id: !input manual_override
                                     state: "off"
+                                  - wait_template: >-
+                                      {% if states(head_entity) != mode %}
+                                        false
+                                      {% else %}
+                                        {% set ns = namespace(ready=true) %}
+                                        {% for entity in extra_temp_targets_to_update %}
+                                          {% if states(entity) != mode %}
+                                            {% set ns.ready = false %}
+                                          {% endif %}
+                                        {% endfor %}
+                                        {{ ns.ready }}
+                                      {% endif %}
+                                    timeout: "00:00:20"
+                                    continue_on_timeout: true
                                   - variables:
                                       ready_extra_temp_targets_to_update: >-
                                         {% if states(head_entity) != mode %}
@@ -729,6 +743,11 @@ actions:
                                         - condition: state
                                           entity_id: !input manual_override
                                           state: "off"
+                                        - wait_template: "{{ states(head_entity) == mode and states(repeat.item) == mode }}"
+                                          timeout: "00:00:10"
+                                          continue_on_timeout: true
+                                        - condition: template
+                                          value_template: "{{ states(head_entity) == mode and states(repeat.item) == mode }}"
                                         - action: climate.set_temperature
                                           continue_on_error: true
                                           target:


### PR DESCRIPTION
## Summary

Ensure optional zone temperature climate entities are only updated after the main climate entity and target zone climate entity confirm they are in the requested `heat` or `cool` mode. This prevents zone temperature writes while the HVAC controller is still transitioning modes, which can produce `Zone temperature can only be changed when the main climate mode is heat or cool` errors.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
git diff --check HEAD~1 HEAD
ruby -e 'require "yaml"; YAML.load_file("blueprints/automation/multi_zone_climate.yaml"); puts "yaml ok"'
python3 scripts/ha_blueprint_validate.py blueprints/automation/multi_zone_climate.yaml
```

`python3 scripts/ha_blueprint_validate.py blueprints/automation/multi_zone_climate.yaml` could not complete in this workspace because the `homeassistant` Python package is not installed:

```text
ModuleNotFoundError: No module named 'homeassistant'
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The fix adds a mode-confirmation wait before zone temperature sync and re-checks both the head climate entity and the current zone climate entity immediately before each zone `climate.set_temperature` call.