### PR TITLE
Harden schedule climate control guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dynamic Multi‑Zone Climate Schedule (2025‑06)
 
-This repository provides a Home Assistant blueprint that coordinates a single HVAC head-unit across multiple zones. It selects a global heating, cooling or drying mode based on the most urgent zone, staggers damper changes for each zone, and explicitly shuts the system down when the schedule ends, nobody is home, or the automation is disabled.
+This repository provides a Home Assistant blueprint that coordinates a single HVAC head-unit across multiple zones. It selects a global heating, cooling or drying mode based on the most urgent zone, staggers damper changes for each zone, and only controls devices while its own schedule window is active. During the active window it shuts the system down when nobody is home, the automation is disabled, or no zone is calling for conditioning.
 
 ## Importing the Blueprint
 
@@ -24,7 +24,7 @@ When creating an automation from the blueprint you will need to provide:
 - **Damper Controller Availability Entity** – optional reachability entity for the zone controller. For Daikin AirBase, use a ping/connectivity sensor for the AirBase IP so damper writes are skipped while the controller is offline or not responding.
 - **Zone Configuration** – edit the YAML list of zones to specify each zone's damper switch and one or more temperature and/or humidity sensors. Optional overrides let you adjust thresholds per zone. Up to eight zones are supported.
 - **Zone Enable Flags** – optionally provide an `input_boolean` per zone to dynamically enable or disable that zone's damper.
-- **Enable/Override Flags** – input_boolean entities used to enable the schedule and to pause active automatic control manually. When the schedule window ends, nobody is home, or the automation is disabled, the blueprint turns the head unit off and closes dampers.
+- **Enable/Override Flags** – input_boolean entities used to enable the schedule and to pause active automatic control manually. Outside the schedule window, or while manual override is on, the blueprint leaves the head unit and dampers alone. During the active window, if nobody is home or the automation is disabled, it turns the head unit off and closes dampers.
 - **Damper Update Delay** – seconds to wait between zone damper changes.
 - **Update Interval** – how often the blueprint re-evaluates all zones (`1m`, `5m`, `10m`, `15m`).
 - **Hysteresis Values** – optional stop-point buffers. For example, with a cool threshold of `23°C` and cool hysteresis of `0.5°C`, cooling starts at `23°C`, stops at `22.5°C`, then waits until the zone rises back to `23°C`.

--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -405,7 +405,7 @@ actions:
         {% endif %}
 
       automation_active: >-
-        {{ is_state(enabled_flag_entity, 'on') and presence_active and schedule_active }}
+        {{ is_state(enabled_flag_entity, 'on') and (presence_active | bool) and (schedule_active | bool) }}
 
       damper_controller_available_state: >-
         {% if damper_controller_available_entity in [none, '', []] %}
@@ -483,13 +483,13 @@ actions:
               {% set cool_ref = cool_stop if cool_active else cool_start %}
               {% set dry_ref = dry_stop if dry_active else dry_start %}
 
-              {% set heat_needed = allow_heat and temp is not none and (temp < heat_start or (heat_active and temp < heat_stop)) %}
+              {% set heat_needed = (allow_heat | bool) and temp is not none and (temp < heat_start or (heat_active and temp < heat_stop)) %}
               {% set heat_sc = (heat_ref - temp)
                  if heat_needed else 0 %}
-              {% set cool_needed = allow_cool and temp is not none and (temp > cool_start or (cool_active and temp > cool_stop)) %}
+              {% set cool_needed = (allow_cool | bool) and temp is not none and (temp > cool_start or (cool_active and temp > cool_stop)) %}
               {% set cool_sc = (temp - cool_ref)
                  if cool_needed else 0 %}
-              {% set dry_needed = allow_dry and hum is not none and temp is not none and temp > z_dry_t and (hum > dry_start or (dry_active and hum > dry_stop)) %}
+              {% set dry_needed = (allow_dry | bool) and hum is not none and temp is not none and temp > z_dry_t and (hum > dry_start or (dry_active and hum > dry_stop)) %}
               {% set dry_sc  = (hum - dry_ref)
                  if dry_needed else 0 %}
               {% set urg = [heat_sc, cool_sc, dry_sc] | max %}
@@ -515,14 +515,20 @@ actions:
         {% set cools = zone_data | map(attribute='cool') | list %}
         {% set drys  = zone_data | map(attribute='dry')  | list %}
         {{ {
-          "heat": (heats | default([0]) | max),
-          "cool": (cools | default([0]) | max),
-          "dry":  (drys  | default([0]) | max)
+          "heat": ((heats | max) if (heats | count > 0) else 0),
+          "cool": ((cools | max) if (cools | count > 0) else 0),
+          "dry":  ((drys  | max) if (drys  | count > 0) else 0)
         } }}
 
       mode: >-
         {% set best = scores | dictsort(by='value', reverse=true) | first %}
         {{ best[0] if best and best[1] > 0 else 'off' }}
+
+      has_valid_zone_reading: >-
+        {{ zone_data
+           | selectattr('temp', 'ne', none)
+           | list
+           | count > 0 }}
 
       zone_data_for_mode: >-
         {% if mode in ['heat', 'cool', 'dry'] %}
@@ -593,6 +599,8 @@ actions:
       needs_mode_update: >-
         {% if mode in [none, '', []] %}
           false
+        {% elif mode == 'off' and not (has_valid_zone_reading | bool) %}
+          false
         {% else %}
           {{ current_hvac_mode != mode }}
         {% endif %}
@@ -615,7 +623,7 @@ actions:
         {% endif %}
 
   - choose:
-      - conditions: "{{ not automation_active }}"
+      - conditions: "{{ (schedule_active | bool) and not (automation_active | bool) and is_state(manual_override_entity, 'off') }}"
         sequence:
           - choose:
               - conditions: "{{ control_head and head_entity not in [none, '', []] and current_hvac_mode != 'off' }}"
@@ -649,7 +657,7 @@ actions:
                                   target:
                                     entity_id: "{{ repeat.item.switch }}"
 
-      - conditions: "{{ is_state(manual_override_entity, 'off') }}"
+      - conditions: "{{ (automation_active | bool) and is_state(manual_override_entity, 'off') }}"
         sequence:
           - choose:
               - conditions: "{{ control_head }}"


### PR DESCRIPTION
## Summary

Harden the multi-zone climate blueprint so schedules only control devices inside their active window and while manual override is off. This fixes cases where one schedule could turn off the shared climate entity outside its own time bounds, and adds safer demand scoring so active schedules do not send `off` from missing or empty zone readings.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
python3 - <<'PY'
import yaml
from pathlib import Path

class Loader(yaml.SafeLoader):
    pass

Loader.add_constructor('!input', lambda loader, node: loader.construct_scalar(node))
path = Path('blueprints/automation/multi_zone_climate.yaml')
with path.open() as f:
    yaml.load(f, Loader=Loader)
print(f'{path} parsed')
PY

git diff --check
```

`python3 scripts/ha_blueprint_validate.py blueprints/automation/multi_zone_climate.yaml` was not run successfully because `homeassistant` is not installed in this checkout.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This repo contains a Home Assistant blueprint rather than a Python custom component, so the translation and Python coverage checklist items are not applicable to this change.
