### PR TITLE
Support entity-backed zone thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Create an automation from the schedule blueprint and select:
 - Schedule times/days, occupancy entities, enable flag, and manual override.
 - The head-unit climate entity and temperature/humidity setpoint helpers.
 - Up to eight zones, each with a damper, sensors, and optional enable flag or
-  threshold overrides.
+  threshold overrides. Overrides may be numbers or `input_number` entities.
 - Optional zone climate entities for direct temperature synchronization.
 
 Zone climate targets use independent offsets: `head target + heat offset` in

--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -260,7 +260,7 @@ blueprint:
         Configure up to 8 zones. For each zone:
           – damper_switch (required)
           – one or more temperature sensors and/or humidity sensors.
-        Optional per-zone overrides let you tailor thresholds if they differ from globals.
+        Optional per-zone overrides accept numbers or entity IDs, letting you tailor thresholds if they differ from globals.
         You may also specify an input_boolean "enabled_flag" to dynamically enable or disable the zone.
       default:
         - name: Zone 1
@@ -528,10 +528,42 @@ actions:
               {% set temp = (t_vals | average(default=none)) %}
               {% set hum  = (h_vals | average(default=none)) %}
 
-              {% set z_low    = (z.low_temp  | default(low,  true)) | float %}
-              {% set z_high   = (z.high_temp | default(high, true)) | float %}
-              {% set z_dry_t  = (z.dry_temp  | default(dry_t, true))| float %}
-              {% set z_hum_h  = (z.hum_high  | default(hum_h, true))| float %}
+              {# Zone overrides may be static numbers or dynamic helper entities. #}
+              {% set z_low_raw = z.low_temp | default(none) %}
+              {% if z_low_raw in [none, ''] %}
+                {% set z_low = low | float %}
+              {% elif z_low_raw is string and '.' in z_low_raw %}
+                {% set z_low = states(z_low_raw) | float(default=(low | float)) %}
+              {% else %}
+                {% set z_low = z_low_raw | float(default=(low | float)) %}
+              {% endif %}
+
+              {% set z_high_raw = z.high_temp | default(none) %}
+              {% if z_high_raw in [none, ''] %}
+                {% set z_high = high | float %}
+              {% elif z_high_raw is string and '.' in z_high_raw %}
+                {% set z_high = states(z_high_raw) | float(default=(high | float)) %}
+              {% else %}
+                {% set z_high = z_high_raw | float(default=(high | float)) %}
+              {% endif %}
+
+              {% set z_dry_raw = z.dry_temp | default(none) %}
+              {% if z_dry_raw in [none, ''] %}
+                {% set z_dry_t = dry_t | float %}
+              {% elif z_dry_raw is string and '.' in z_dry_raw %}
+                {% set z_dry_t = states(z_dry_raw) | float(default=(dry_t | float)) %}
+              {% else %}
+                {% set z_dry_t = z_dry_raw | float(default=(dry_t | float)) %}
+              {% endif %}
+
+              {% set z_hum_raw = z.hum_high | default(none) %}
+              {% if z_hum_raw in [none, ''] %}
+                {% set z_hum_h = hum_h | float %}
+              {% elif z_hum_raw is string and '.' in z_hum_raw %}
+                {% set z_hum_h = states(z_hum_raw) | float(default=(hum_h | float)) %}
+              {% else %}
+                {% set z_hum_h = z_hum_raw | float(default=(hum_h | float)) %}
+              {% endif %}
 
               {% set heat_start = z_low %}
               {% set heat_stop = z_low + hbuf %}

--- a/tests/blueprint_inputs.yaml
+++ b/tests/blueprint_inputs.yaml
@@ -41,8 +41,8 @@ blueprints/automation/multi_zone_climate.yaml:
       enabled_flag: input_boolean.validation_main_zone
       temp_sensors: sensor.validation_living_temperature
       humidity_sensors: sensor.validation_living_humidity
-      low_temp: null
-      high_temp: null
+      low_temp: input_number.validation_main_heat_threshold
+      high_temp: input_number.validation_main_cool_threshold
       dry_temp: null
       hum_high: null
     - name: Bedrooms
@@ -50,8 +50,8 @@ blueprints/automation/multi_zone_climate.yaml:
       enabled_flag: input_boolean.validation_bedrooms_zone
       temp_sensors: sensor.validation_bedroom_temperature
       humidity_sensors: sensor.validation_bedroom_humidity
-      low_temp: null
-      high_temp: null
+      low_temp: input_number.validation_bedrooms_heat_threshold
+      high_temp: input_number.validation_bedrooms_cool_threshold
       dry_temp: null
       hum_high: null
   trigger_delay: 20

--- a/tests/test_classifier_regressions.py
+++ b/tests/test_classifier_regressions.py
@@ -200,6 +200,24 @@ class ClimateChangeClassifierRegressionTests(unittest.TestCase):
         self.assertIn("zone_cool_temp_offset | float(0)", self.schedule)
         self.assertIn("zone_cool_temperature_offset: 3", self.inputs)
 
+    def test_zone_threshold_overrides_accept_helper_entities(self) -> None:
+        """Per-zone dashboard helpers must resolve to their current states."""
+        for override, fallback in (
+            ("z_low_raw", "low"),
+            ("z_high_raw", "high"),
+            ("z_dry_raw", "dry_t"),
+            ("z_hum_raw", "hum_h"),
+        ):
+            with self.subTest(override=override):
+                self.assertIn(f"states({override})", self.schedule)
+                self.assertIn(f"default=({fallback} | float)", self.schedule)
+        self.assertIn(
+            "low_temp: input_number.validation_main_heat_threshold", self.inputs
+        )
+        self.assertIn(
+            "high_temp: input_number.validation_bedrooms_cool_threshold", self.inputs
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Allow per-zone temperature, dry-temperature, and humidity overrides to reference
helper entities as well as static numbers. Unavailable helpers fall back to the
corresponding global threshold.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [x] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
python3 -m unittest discover -s tests -p 'test_*.py'
ruff check .
git diff --check
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The validation fixture now exercises entity-backed Main and Bedrooms thresholds.
