### PR TITLE
Fix delayed damper restore classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ active window has no demand.
 Use the classifier with the schedule's manual-override helper. It watches the
 head unit, zone climate entities, and dampers. Schedule markers and a dedicated
 guard `input_boolean` and `timer` prevent scheduled writes from being mistaken
-for UI, HomeKit, or physical-device changes.
+for UI, HomeKit, or physical-device changes. A bounded post-schedule restore
+window filters the root-context `off` to `on` damper rebound reported by some
+controllers after shutdown. Later HomeKit and physical-device changes still
+enable manual override; set the restore window to zero to disable the filter.
 
 ## Setup
 

--- a/blueprints/automation/climate_change_classifier.yaml
+++ b/blueprints/automation/climate_change_classifier.yaml
@@ -96,6 +96,16 @@ blueprint:
           max: 60
           unit_of_measurement: "s"
 
+    damper_restore_window_seconds:
+      name: Delayed Damper Restore Window
+      description: Seconds after the schedule guard finishes during which a root-context damper off-to-on change is treated as a delayed controller restoration when the head unit remains off. Set to 0 to disable.
+      default: 150
+      selector:
+        number:
+          min: 0
+          max: 900
+          unit_of_measurement: "s"
+
 triggers:
   - trigger: state
     id: temp
@@ -222,6 +232,7 @@ actions:
       damper_entities: !input damper_switches
       schedule_hold_seconds: !input schedule_hold_seconds
       state_settle_seconds: !input state_settle_seconds
+      damper_restore_window_seconds: !input damper_restore_window_seconds
       schedule_guard_flag_entity: !input schedule_guard_flag
       schedule_guard_timer_entity: !input schedule_guard_timer
       manual_override_entity: !input manual_override
@@ -362,6 +373,36 @@ actions:
           true
         {% endif %}
 
+      ambiguous_state_is_delayed_damper_restore: >-
+        {% set restore_window = damper_restore_window_seconds | int(150) %}
+        {% if trigger.platform != 'state'
+              or trigger.from_state is none
+              or trigger.to_state is none
+              or restore_window <= 0 %}
+          false
+        {% elif not trigger.entity_id.startswith('switch.')
+              or trigger.from_state.state != 'off'
+              or trigger.to_state.state != 'on'
+              or not is_state(head_entity, 'off')
+              or not is_state(schedule_guard_flag_entity, 'off')
+              or not is_state(schedule_guard_timer_entity, 'idle') %}
+          false
+        {% else %}
+          {% set restored_at = as_timestamp(trigger.to_state.last_changed, 0) %}
+          {% set guard_ended_at = as_timestamp(states[schedule_guard_timer_entity].last_changed, 0) %}
+          {% set guard_started_at = guard_ended_at - (schedule_hold_seconds | int(30)) %}
+          {% set damper_turned_off_at = as_timestamp(trigger.from_state.last_changed, 0) %}
+          {% set head_turned_off_at = as_timestamp(states[head_entity].last_changed, 0) %}
+          {% set elapsed = restored_at - guard_ended_at %}
+          {{ guard_ended_at > 0
+             and damper_turned_off_at >= guard_started_at
+             and damper_turned_off_at <= guard_ended_at
+             and head_turned_off_at >= guard_started_at
+             and head_turned_off_at <= guard_ended_at
+             and elapsed >= 0
+             and elapsed <= restore_window }}
+        {% endif %}
+
       schedule_guard_duration: >-
         {% set total = schedule_hold_seconds | int(30) %}
         {{ '%02d:%02d:%02d' | format(total // 3600, (total % 3600) // 60, total % 60) }}
@@ -483,6 +524,10 @@ actions:
           - alias: Ignore unavailable, unknown and non-change updates
             condition: template
             value_template: "{{ state_change_is_valid }}"
+          - alias: Ignore a delayed post-schedule controller damper restoration
+            condition: template
+            value_template: >-
+              {{ not (ambiguous_state_is_delayed_damper_restore | bool) }}
           - alias: Do not treat known schedule windows as manual
             condition: template
             value_template: "{{ not (schedule_guard_active | bool) }}"

--- a/tests/test_classifier_regressions.py
+++ b/tests/test_classifier_regressions.py
@@ -92,6 +92,51 @@ class ClimateChangeClassifierRegressionTests(unittest.TestCase):
             "State change clearly initiated by a HA user context", self.classifier
         )
 
+    def test_delayed_damper_restore_is_bounded_to_a_recent_guard(self) -> None:
+        """Only the controller's post-schedule off-to-on rebound is ignored."""
+        user_context = self.classifier.split(
+            "- alias: State change clearly initiated by a HA user context", maxsplit=1
+        )[1].split(
+            "- alias: Ambiguous direct state change, likely HomeKit/physical/device-originated",
+            maxsplit=1,
+        )[0]
+        ambiguous_context = self.classifier.split(
+            "- alias: Ambiguous direct state change, likely HomeKit/physical/device-originated",
+            maxsplit=1,
+        )[1]
+        restore_detection = self.classifier.split(
+            "ambiguous_state_is_delayed_damper_restore: >-", maxsplit=1
+        )[1].split("schedule_guard_duration: >-", maxsplit=1)[0]
+
+        self.assertNotIn("ambiguous_state_is_delayed_damper_restore", user_context)
+        self.assertIn(
+            "Ignore a delayed post-schedule controller damper restoration",
+            ambiguous_context,
+        )
+        self.assertIn(
+            "not (ambiguous_state_is_delayed_damper_restore | bool)",
+            ambiguous_context,
+        )
+        for constraint in (
+            "trigger.entity_id.startswith('switch.')",
+            "trigger.from_state.state != 'off'",
+            "trigger.to_state.state != 'on'",
+            "is_state(head_entity, 'off')",
+            "is_state(schedule_guard_flag_entity, 'off')",
+            "is_state(schedule_guard_timer_entity, 'idle')",
+            "guard_started_at = guard_ended_at - (schedule_hold_seconds | int(30))",
+            "damper_turned_off_at >= guard_started_at",
+            "damper_turned_off_at <= guard_ended_at",
+            "head_turned_off_at >= guard_started_at",
+            "head_turned_off_at <= guard_ended_at",
+            "elapsed >= 0",
+            "elapsed <= restore_window",
+        ):
+            with self.subTest(constraint=constraint):
+                self.assertIn(constraint, restore_detection)
+        self.assertIn("default: 150", self.classifier)
+        self.assertIn("Set to 0 to disable", self.classifier)
+
     def test_settle_conditions_query_live_state(self) -> None:
         """The post-delay conditions must not reuse pre-delay booleans."""
         settle_sequence = self.classifier.split(


### PR DESCRIPTION
## Summary

Fixes false manual-override classification when a controller restores a damper state after scheduled HVAC shutdown. The classifier now recognizes only a bounded, timestamp-correlated damper `off` to `on` rebound whose head-unit and damper-off transitions occurred during the completed schedule guard.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py'
ruff check tests/test_classifier_regressions.py scripts/ha_blueprint_validate.py
git diff --check
uv run --python /Users/james/.local/share/uv/python/cpython-3.13.2-macos-aarch64-none/bin/python3.13 --with homeassistant==2025.6.0 python scripts/ha_blueprint_validate.py blueprints/automation/climate_change_classifier.yaml blueprints/automation/multi_zone_climate.yaml
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Home Assistant recorder history showed 16 delayed Bedrooms-damper rebounds, all while the head unit was off; 11 caused manual override. The observed rebound occurred about 91 seconds after the schedule guard completed and is covered by the new configurable restore window and guard-interval correlation.