### PR TITLE
Allow damper restore while head is already off

### DIFF
--- a/blueprints/automation/climate_change_classifier.yaml
+++ b/blueprints/automation/climate_change_classifier.yaml
@@ -392,13 +392,10 @@ actions:
           {% set guard_ended_at = as_timestamp(states[schedule_guard_timer_entity].last_changed, 0) %}
           {% set guard_started_at = guard_ended_at - (schedule_hold_seconds | int(30)) %}
           {% set damper_turned_off_at = as_timestamp(trigger.from_state.last_changed, 0) %}
-          {% set head_turned_off_at = as_timestamp(states[head_entity].last_changed, 0) %}
           {% set elapsed = restored_at - guard_ended_at %}
           {{ guard_ended_at > 0
              and damper_turned_off_at >= guard_started_at
              and damper_turned_off_at <= guard_ended_at
-             and head_turned_off_at >= guard_started_at
-             and head_turned_off_at <= guard_ended_at
              and elapsed >= 0
              and elapsed <= restore_window }}
         {% endif %}

--- a/tests/test_classifier_regressions.py
+++ b/tests/test_classifier_regressions.py
@@ -93,7 +93,7 @@ class ClimateChangeClassifierRegressionTests(unittest.TestCase):
         )
 
     def test_delayed_damper_restore_is_bounded_to_a_recent_guard(self) -> None:
-        """Only the controller's post-schedule off-to-on rebound is ignored."""
+        """A guarded damper-off rebound is ignored even if the head was off."""
         user_context = self.classifier.split(
             "- alias: State change clearly initiated by a HA user context", maxsplit=1
         )[1].split(
@@ -127,13 +127,12 @@ class ClimateChangeClassifierRegressionTests(unittest.TestCase):
             "guard_started_at = guard_ended_at - (schedule_hold_seconds | int(30))",
             "damper_turned_off_at >= guard_started_at",
             "damper_turned_off_at <= guard_ended_at",
-            "head_turned_off_at >= guard_started_at",
-            "head_turned_off_at <= guard_ended_at",
             "elapsed >= 0",
             "elapsed <= restore_window",
         ):
             with self.subTest(constraint=constraint):
                 self.assertIn(constraint, restore_detection)
+        self.assertNotIn("head_turned_off_at", restore_detection)
         self.assertIn("default: 150", self.classifier)
         self.assertIn("Set to 0 to disable", self.classifier)
 


### PR DESCRIPTION
## Summary

Fixes delayed damper restorations being misclassified when a scheduled damper-off action occurs while the HVAC head is already off. The detector still requires the damper's preceding off transition to fall within the completed schedule guard, but no longer requires a new head-unit off transition during that guard.

The redundant live `Climate Scheduler Guard: Scheduled Automations` automation was also disabled because the classifier and companion schedule now manage guards around actual control calls.

## Related Issues

Follow-up to #40.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py'
ruff check tests/test_classifier_regressions.py scripts/ha_blueprint_validate.py
git diff --check
uv run --python /Users/james/.local/share/uv/python/cpython-3.13.2-macos-aarch64-none/bin/python3.13 --with homeassistant==2025.6.0 python scripts/ha_blueprint_validate.py blueprints/automation/climate_change_classifier.yaml blueprints/automation/multi_zone_climate.yaml
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Live Home Assistant history showed the head unit had already been off since 11:00, the scheduled Bedrooms damper changed off at 12:10:59 during the guard, the guard ended at 12:11:29, and the controller restored the damper on at 12:12:59. The previous head-transition correlation incorrectly rejected this sequence.