### PR TITLE
Keep one damper open for AirBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Create an automation from the schedule blueprint and select:
 - The head-unit climate entity and temperature/humidity setpoint helpers.
 - Up to eight zones, each with a damper, sensors, and optional enable flag or
   threshold overrides. Overrides may be numbers or `input_number` entities.
+- For controllers such as Daikin AirBase that reject an all-zones-off state,
+  enable **Keep One Damper Open** and optionally select a preferred spill
+  damper. With no demand, the schedule otherwise retains a currently open zone.
 - Optional zone climate entities for direct temperature synchronization.
 
 Zone climate targets use independent offsets: `head target + heat offset` in
@@ -77,4 +80,8 @@ After updating an imported blueprint, reload automations in Home Assistant.
   watchdog interval shorter than a worst-case automation run.
 - If a zone rejects a temperature update, check its current min/max range and
   increase the zone settle delay.
+- If the controller turns a zone back on after every all-zones-off request,
+  enable **Keep One Damper Open**. Opening a preferred spill zone is ordered
+  before closing the previous zone, which is closed only after another planned
+  airflow damper is confirmed open.
 - Use the automation trace to confirm which trigger and condition stopped a run.

--- a/blueprints/automation/multi_zone_climate.yaml
+++ b/blueprints/automation/multi_zone_climate.yaml
@@ -91,6 +91,20 @@ blueprint:
       default: true
       selector: { boolean: {} }
 
+    keep_one_damper_open:
+      name: Keep One Damper Open
+      description: Prevent controllers that reject an all-zones-off state from bouncing a damper back on. When no zone has demand, retain a currently open damper or open the preferred spill damper below. Disabled by default for compatibility with existing schedules.
+      default: false
+      selector: { boolean: {} }
+
+    preferred_spill_damper:
+      name: Preferred Spill Damper (optional)
+      description: Damper to keep open when no zone has demand. It must also appear in Zones Configuration. If omitted or unavailable, the blueprint retains the first currently open damper, then falls back to the first available configured damper.
+      default: ""
+      selector:
+        entity:
+          domain: switch
+
     damper_controller_available:
       name: Damper Controller Availability Entity (optional)
       description: Optional binary_sensor, sensor, or switch that reports whether the damper controller is reachable. If provided, damper service calls are skipped unless this entity is on, home, open, or connected.
@@ -458,6 +472,8 @@ actions:
       allow_dry: !input allow_dry
       control_head: !input control_head_unit
       control_dampers: !input control_dampers
+      keep_one_damper_open: !input keep_one_damper_open
+      preferred_spill_damper: !input preferred_spill_damper
       damper_controller_available_entity: !input damper_controller_available
       zone_temp_entities: !input zone_temperature_entities
       zone_heat_temp_offset: !input zone_temperature_offset
@@ -723,7 +739,7 @@ actions:
         {% endif %}
 
       damper_updates: >-
-        {% set ns = namespace(items=[]) %}
+        {% set ns = namespace(open_items=[], close_items=[], demand_switches=[], airflow_switches=[], keeper=none) %}
         {% if control_dampers and (dampers_available | bool) %}
           {% set candidates = zone_data_for_mode if (automation_active | bool) else zone_data %}
           {% for item in candidates %}
@@ -731,18 +747,61 @@ actions:
                and ((mode == 'heat' and item.heat > 0)
                  or (mode == 'cool' and item.cool > 0)
                  or (mode == 'dry' and item.dry > 0)) %}
+            {% if wants_open %}
+              {% set ns.demand_switches = ns.demand_switches + [item.switch] %}
+            {% endif %}
+          {% endfor %}
+
+          {# Some zone controllers will not retain an all-zones-off setting. #}
+          {% if (keep_one_damper_open | bool) and ns.demand_switches | length == 0 %}
+            {% set candidate_switches = candidates | map(attribute='switch') | list %}
+            {% if preferred_spill_damper not in [none, '', []]
+               and preferred_spill_damper in candidate_switches
+               and states(preferred_spill_damper) not in ['unknown', 'unavailable'] %}
+              {% set ns.keeper = preferred_spill_damper %}
+            {% endif %}
+            {% if ns.keeper is none %}
+              {% for item in candidates %}
+                {% if ns.keeper is none and is_state(item.switch, 'on') %}
+                  {% set ns.keeper = item.switch %}
+                {% endif %}
+              {% endfor %}
+            {% endif %}
+            {% if ns.keeper is none %}
+              {% for item in candidates %}
+                {% if ns.keeper is none and states(item.switch) not in ['unknown', 'unavailable'] %}
+                  {% set ns.keeper = item.switch %}
+                {% endif %}
+              {% endfor %}
+            {% endif %}
+          {% endif %}
+
+          {% set ns.airflow_switches = ns.demand_switches %}
+          {% if ns.keeper is not none %}
+            {% set ns.airflow_switches = ns.airflow_switches + [ns.keeper] %}
+          {% endif %}
+
+          {% for item in candidates %}
+            {% set wants_open = item.switch in ns.demand_switches or item.switch == ns.keeper %}
             {% set switch_state = states(item.switch) %}
             {% if switch_state not in ['unknown', 'unavailable']
                and ((wants_open and switch_state != 'on')
                  or ((not wants_open) and switch_state == 'on')) %}
-              {% set ns.items = ns.items + [{
+              {% set update = {
                 'switch': item.switch,
-                'desired': 'on' if wants_open else 'off'
-              }] %}
+                'desired': 'on' if wants_open else 'off',
+                'airflow_switches': ns.airflow_switches
+              } %}
+              {% if wants_open %}
+                {% set ns.open_items = ns.open_items + [update] %}
+              {% else %}
+                {% set ns.close_items = ns.close_items + [update] %}
+              {% endif %}
             {% endif %}
           {% endfor %}
         {% endif %}
-        {{ ns.items }}
+        {# Always establish an airflow path before closing the previous one. #}
+        {{ ns.open_items + ns.close_items }}
 
   - choose:
       - conditions: "{{ (schedule_active | bool) and not (automation_active | bool) and is_state(manual_override_entity, 'off') }}"
@@ -774,15 +833,30 @@ actions:
                         - condition: state
                           entity_id: !input manual_override
                           state: "off"
-                        - condition: template
-                          value_template: "{{ states(repeat.item.switch) == 'on' }}"
-                        - event: multi_zone_climate_scheduled_control
-                          event_data:
-                            entity_id: "{{ repeat.item.switch }}"
-                        - action: switch.turn_off
-                          continue_on_error: true
-                          target:
-                            entity_id: "{{ repeat.item.switch }}"
+                        - choose:
+                            - conditions: "{{ repeat.item.desired == 'on' and states(repeat.item.switch) != 'on' }}"
+                              sequence:
+                                - event: multi_zone_climate_scheduled_control
+                                  event_data:
+                                    entity_id: "{{ repeat.item.switch }}"
+                                - action: switch.turn_on
+                                  continue_on_error: true
+                                  target:
+                                    entity_id: "{{ repeat.item.switch }}"
+                            - conditions: >-
+                                {{ repeat.item.desired == 'off'
+                                   and states(repeat.item.switch) == 'on'
+                                   and (repeat.item.airflow_switches | length == 0
+                                     or expand(repeat.item.airflow_switches)
+                                       | selectattr('state', 'eq', 'on') | list | count > 0) }}
+                              sequence:
+                                - event: multi_zone_climate_scheduled_control
+                                  event_data:
+                                    entity_id: "{{ repeat.item.switch }}"
+                                - action: switch.turn_off
+                                  continue_on_error: true
+                                  target:
+                                    entity_id: "{{ repeat.item.switch }}"
 
       - conditions: "{{ (automation_active | bool) and is_state(manual_override_entity, 'off') }}"
         sequence:
@@ -937,7 +1011,12 @@ actions:
                                   continue_on_error: true
                                   target:
                                     entity_id: "{{ repeat.item.switch }}"
-                            - conditions: "{{ repeat.item.desired == 'off' and states(repeat.item.switch) == 'on' }}"
+                            - conditions: >-
+                                {{ repeat.item.desired == 'off'
+                                   and states(repeat.item.switch) == 'on'
+                                   and (repeat.item.airflow_switches | length == 0
+                                     or expand(repeat.item.airflow_switches)
+                                       | selectattr('state', 'eq', 'on') | list | count > 0) }}
                               sequence:
                                 - event: multi_zone_climate_scheduled_control
                                   event_data:

--- a/tests/blueprint_inputs.yaml
+++ b/tests/blueprint_inputs.yaml
@@ -35,6 +35,8 @@ blueprints/automation/multi_zone_climate.yaml:
     - climate.validation_main_temperature
     - climate.validation_bedrooms_temperature
   zone_cool_temperature_offset: 3
+  keep_one_damper_open: true
+  preferred_spill_damper: switch.validation_main_damper
   zones:
     - name: Main
       damper_switch: switch.validation_main_damper

--- a/tests/test_classifier_regressions.py
+++ b/tests/test_classifier_regressions.py
@@ -77,7 +77,7 @@ class ClimateChangeClassifierRegressionTests(unittest.TestCase):
         self.assertIn(
             "Companion schedule announced a monitored control call", self.classifier
         )
-        self.assertEqual(self.schedule.count(f"event: {marker}"), 7)
+        self.assertEqual(self.schedule.count(f"event: {marker}"), 8)
         self.assertEqual(
             self.schedule.count(f"event: {marker}"),
             self.schedule.count("action: climate.")
@@ -236,6 +236,51 @@ class ClimateChangeClassifierRegressionTests(unittest.TestCase):
             self.schedule.count('for_each: "{{ damper_updates }}"'), 2
         )
         self.assertNotIn('for_each: "{{ zone_data_for_mode }}"', self.schedule)
+
+    def test_schedule_can_retain_a_spill_damper_when_demand_is_off(self) -> None:
+        """Opt-in spill handling must never plan an all-dampers-off state."""
+        planner = self.schedule.split("damper_updates: >-", maxsplit=1)[1].split(
+            "  - choose:", maxsplit=1
+        )[0]
+        self.assertIn("keep_one_damper_open: !input keep_one_damper_open", self.schedule)
+        self.assertIn(
+            "preferred_spill_damper: !input preferred_spill_damper", self.schedule
+        )
+        self.assertIn("ns.demand_switches | length == 0", planner)
+        self.assertIn("is_state(item.switch, 'on')", planner)
+        self.assertIn("item.switch == ns.keeper", planner)
+        self.assertIn("ns.open_items + ns.close_items", planner)
+        self.assertIn("keep_one_damper_open: true", self.inputs)
+        self.assertIn(
+            "preferred_spill_damper: switch.validation_main_damper", self.inputs
+        )
+
+    def test_inactive_schedule_can_open_the_spill_damper_before_closing(self) -> None:
+        """The shutdown path must confirm the spill damper before closing."""
+        inactive_sequence = self.schedule.split(
+            "- conditions: \"{{ (schedule_active | bool) and not (automation_active | bool)",
+            maxsplit=1,
+        )[1].split(
+            "- conditions: \"{{ (automation_active | bool)", maxsplit=1
+        )[0]
+        self.assertIn("repeat.item.desired == 'on'", inactive_sequence)
+        self.assertIn("action: switch.turn_on", inactive_sequence)
+        self.assertIn("repeat.item.airflow_switches", inactive_sequence)
+        self.assertIn("expand(repeat.item.airflow_switches)", inactive_sequence)
+        self.assertLess(
+            self.schedule.index("{{ ns.open_items + ns.close_items }}"),
+            self.schedule.index('for_each: "{{ damper_updates }}"'),
+        )
+
+    def test_every_damper_close_requires_a_live_airflow_path(self) -> None:
+        """A failed or delayed open command must leave the old zone open."""
+        self.assertIn("'airflow_switches': ns.airflow_switches", self.schedule)
+        self.assertEqual(
+            self.schedule.count("expand(repeat.item.airflow_switches)"), 2
+        )
+        self.assertEqual(
+            self.schedule.count("selectattr('state', 'eq', 'on')"), 2
+        )
 
     def test_heat_and_cool_zone_offsets_are_independent(self) -> None:
         """Narrow-range zone climates need distinct heat and cool targets."""


### PR DESCRIPTION
## Summary

Prevent Daikin AirBase and similar zone controllers from receiving an all-zones-off command when configured to retain an airflow path. The schedule now keeps a current zone open or uses an optional preferred spill damper, confirms the replacement is actually open before closing the previous zone, and preserves existing behavior by default.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [x] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
python3 -m unittest discover -s tests -v
ruff check .
docker run --rm -v "$PWD:/work" -w /work docker-ha-dev:latest bash -lc '<validate expanded blueprints, triggers, conditions, and actions with Home Assistant Core>'
```

Live Home Assistant template rendering confirmed that Bedrooms is retained when it is the current spill zone, a preferred Main zone is planned before Bedrooms closes, and a failed or delayed Main open blocks the Bedrooms close.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The observed controller accepted the final-zone-off write temporarily, then restored Bedrooms at the next integration poll. The new option avoids issuing that final close and is disabled by default for existing schedules.
